### PR TITLE
Bump testify version.

### DIFF
--- a/golang-base/dependencies
+++ b/golang-base/dependencies
@@ -5,7 +5,8 @@ github.com/jessevdk/go-flags         1679536dcc895411a9f5848d9a0250be7856448c
 github.com/juju/loggo                dc8e19f7c70a62a59c69c40f85b8df09ff20742c
 github.com/lib/pq                    835d5eb08da4541f26181e6958d7400da769e44b
 github.com/pebbe/zmq4                e68cf30b3e77fc66eee7f5e33af638b976ffaba2
-github.com/stretchr/testify          ae37dedcaae6fce497569786a8694aa3daa97abf
+github.com/stretchr/testify          e4ec8152c15fc46bd5056ce65997a07c7d415325
+github.com/stretchr/objx             cbeaeb16a013161a98496fad62933b1d21786672
 github.com/vds/oops                  3e439e652bab85024a8b6965f5de7319d8a7b62e
 golang.org/x/crypto/ripemd160        280be005b3a662119e76768fe9d91171c1142511
 gopkg.in/validator.v2                8e445b9dc14ab1a1a78cc1f712df991307173ee6


### PR DESCRIPTION
The one we used had a nasty bug in assert.Equal (false positives).