### PR TITLE
Adding configuration

### DIFF
--- a/golang-base/postgres/postgres_notary.sql
+++ b/golang-base/postgres/postgres_notary.sql
@@ -1,5 +1,12 @@
 -- Setup ran by the notary_test user. Setup schema etc.
 
+CREATE TABLE IF NOT EXISTS configuration (
+       id text PRIMARY KEY,
+       configuration text
+);
+
+INSERT INTO configuration (id, configuration) VALUES ('notary_configuration', '{"host":"127.0.0.1", "port":8123}');
+
 CREATE TABLE IF NOT EXISTS key_value (key bytea PRIMARY KEY, value bytea);
 
 -- Taken from example 40-2


### PR DESCRIPTION
The notary configuration, apart from the parameters used to connect to the Postgresql db, are store in the database. This allow to share common configuration among gotary server instances. It's a suboptimal solution, but very cheap, and works for the moment. In the long term the ideal solution would be a proper distributed configuration system like etcd.