### PR TITLE
build_image: also build when Dockerfile is not changed

### DIFF
--- a/build_image
+++ b/build_image
@@ -42,7 +42,8 @@ build_image () {
     docker rmi "$tag"
 }
 
-for file in $(git diff --name-only $(git merge-base HEAD origin/master) |
-        grep '^\(golang\|java\)-base'); do
-    build_image $(dirname $file)
+folders=$(git diff --name-only $(git merge-base HEAD origin/master) |
+    sed -n 's/^\(\(golang\|java\)-base\)\/.\+/\1/p' | sort -u)
+for folder in $folders; do
+    build_image $folder
 done


### PR DESCRIPTION
We wrongly assumed that only Dockerfiles are changed but we
also maintain multiple helper scripts that could be changed
without touching the Dockerfile. Therefore, we want to check
the Dockerfile when there are any changes in its folder.

Closes #19